### PR TITLE
feature/sc-36824/ecs-service-fargate-otel-deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ workflows:
                       - aws-cli/setup:
                             profile_name: ecs_oidc
                             role_arn: $ECS_OIDC_ROLE
-                  cluster: clard-prod-cluster
-                  container_image_name_updates: container=clark-gateway,tag=latest
-                  family: clark-gateway
+                  cluster: prd-secured-cluster-use1
+                  container_image_name_updates: container=prd-clark-gateway-use1,tag=latest
+                  family: prd-clark-gateway-use1
                   profile_name: ecs_oidc
                   verify_revision_is_deployed: true


### PR DESCRIPTION
## What this PR does / why we need it

Updated config.yml release-prod workflow, deploy_service_update job to use newer naming conventions for ECS cluster, container, and family name to deploy to new infrastructure running on Fargate. 

## Acceptance Criteria Met

-   [ ] Docs changes if needed
-   [ ] Testing changes if needed
-   [ ] All workflow checks passing (automatically enforced)
-   [ ] All review conversations resolved (automatically enforced)
-   [ ] [DCO Sign-off](https://github.com/apps/dco)

