### PR TITLE
Feature/sc 37628/fix large file downloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "clark-gateway",
-    "version": "4.3.1",
+    "version": "4.3.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "clark-gateway",
-            "version": "4.3.1",
+            "version": "4.3.2",
             "license": "ISC",
             "dependencies": {
                 "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "clark-gateway",
-    "version": "4.3.1",
+    "version": "4.3.2",
     "description": "Internet facing gateway application for both of the CLARK and CARD services.",
     "main": "src/app.js",
     "scripts": {

--- a/src/modules/clark/file-module/file.routes.ts
+++ b/src/modules/clark/file-module/file.routes.ts
@@ -8,7 +8,6 @@ export const FILE_ROUTES: ProxyRoute[] = [
     {
         method: HTTPMethod.GET,
         path: "/learning-objects/:learningObjectId/files/:fileId/download",
-        auth: true,
     },
     {
         method: HTTPMethod.PATCH,


### PR DESCRIPTION
## What this PR does / why we need it

Removes authentication from the get files downloads route on Clark. Needed because links that are generated for large files and are placed on ReadMes when learning objects are bundled, need to be accessible and clickable from the public. 
