### PR TITLE
feature/sc-38153/add-get-learning-objects-name-name-route-to

### DIFF
--- a/src/modules/clark/learning-object-module/search.routes.ts
+++ b/src/modules/clark/learning-object-module/search.routes.ts
@@ -10,4 +10,8 @@ export const SEARCH_ROUTES: ProxyRoute[] = [
         method: HTTPMethod.GET,
         path: "/users/:username/learning-objects",
     },
+    {
+        method: HTTPMethod.GET,
+        path: "/learning-objects/name/:name"
+    }
 ];

--- a/src/modules/clark/learning-object-module/search.routes.ts
+++ b/src/modules/clark/learning-object-module/search.routes.ts
@@ -12,6 +12,6 @@ export const SEARCH_ROUTES: ProxyRoute[] = [
     },
     {
         method: HTTPMethod.GET,
-        path: "/learning-objects/name/:name"
+        path: "/learning-objects/name/check/:name"
     }
 ];


### PR DESCRIPTION
Adds the check learning object name route to clark-gateway

story: https://app.shortcut.com/clarkcan/story/38153/add-get-learning-objects-name-name-route-to-clark-service-search-module