### PR TITLE
Feature/sc 38929/deploy learning object mcp to staging and

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3785,6 +3785,7 @@
             "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
             "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "husky": "lib/bin.js"
             },

--- a/src/config/env/env.driver.ts
+++ b/src/config/env/env.driver.ts
@@ -116,7 +116,7 @@ class EnvConfig {
                 HIERARCHY_SERVICE_URI,
                 STANDARD_GUIDELINES_SERVICE_URI,
                 CARD_SERVICE_URI,
-                MCP_SERVICE_URI
+                MCP_SERVICE_URI,
             ].includes(service)
         ) {
             throw new ServiceError(

--- a/src/config/env/env.driver.ts
+++ b/src/config/env/env.driver.ts
@@ -9,6 +9,7 @@ import {
     CORALOGIX_PRIVATE_KEY,
     HIERARCHY_SERVICE_URI,
     ISSUER,
+    MCP_SERVICE_URI,
     NODE_ENV,
     PORT,
     STANDARD_GUIDELINES_SERVICE_URI,
@@ -115,6 +116,7 @@ class EnvConfig {
                 HIERARCHY_SERVICE_URI,
                 STANDARD_GUIDELINES_SERVICE_URI,
                 CARD_SERVICE_URI,
+                MCP_SERVICE_URI
             ].includes(service)
         ) {
             throw new ServiceError(

--- a/src/config/express/express.config.ts
+++ b/src/config/express/express.config.ts
@@ -6,6 +6,7 @@ import { formatMorganJson, httpRequestFilter } from "../logging/logging.driver";
 import { ClarkRouteHandler } from "../../modules/clark/clark.router";
 import { ErrorParser } from "../../middlewares/error-parser";
 import { CardRouteHandler } from "../../modules/card/card.router";
+import { MCPRouteHandler } from "../../modules/mcp/mcp.router";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const version = require("../../../package.json").version;
@@ -42,6 +43,7 @@ export class ExpressConfig {
         // Route Handlers Here
         this.app.use(CardRouteHandler.build());
         this.app.use(ClarkRouteHandler.build());
+        this.app.use(MCPRouteHandler.build());
 
         this.app.use(ErrorParser);
 

--- a/src/config/global.env.ts
+++ b/src/config/global.env.ts
@@ -59,3 +59,8 @@ export const ISSUER = "ISSUER";
  * Required for production & staging
  */
 export const CORALOGIX_PRIVATE_KEY = "CORALOGIX_PRIVATE_KEY";
+
+/**
+ * URI target for the mcp server
+ */
+export const MCP_SERVICE_URI = "MCP_SERVICE_URI";

--- a/src/modules/clark/organization-module/organization.routes.ts
+++ b/src/modules/clark/organization-module/organization.routes.ts
@@ -35,5 +35,5 @@ export const ORGANIZATION_ROUTES: ProxyRoute[] = [
         method: HTTPMethod.POST,
         auth: true,
         path: "/organizations/:organizationId/migrate",
-    }
+    },
 ];

--- a/src/modules/mcp/clark-mcp.router.ts
+++ b/src/modules/mcp/clark-mcp.router.ts
@@ -6,9 +6,6 @@ import { MCP_SERVICE_URI } from "../../config/global.env";
 
 export class ClarkMCPRouteHandler {
     public static build(): Router {
-        return buildProxyRouter(
-            MCP_ROUTES,
-            envConfig.getUri(MCP_SERVICE_URI),
-        );
+        return buildProxyRouter(MCP_ROUTES, envConfig.getUri(MCP_SERVICE_URI));
     }
 }

--- a/src/modules/mcp/clark-mcp.router.ts
+++ b/src/modules/mcp/clark-mcp.router.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import { buildProxyRouter } from "../../shared/functions/build-proxy-router";
+import { MCP_ROUTES } from "./clark-mcp.routes";
+import { envConfig } from "../../config/env/env.driver";
+import { MCP_SERVICE_URI } from "../../config/global.env";
+
+export class ClarkMCPRouteHandler {
+    public static build(): Router {
+        return buildProxyRouter(
+            MCP_ROUTES,
+            envConfig.getUri(MCP_SERVICE_URI),
+        );
+    }
+}

--- a/src/modules/mcp/clark-mcp.routes.ts
+++ b/src/modules/mcp/clark-mcp.routes.ts
@@ -5,5 +5,5 @@ export const MCP_ROUTES: ProxyRoute[] = [
     {
         method: HTTPMethod.POST,
         path: "/mcp",
-    }
-]
+    },
+];

--- a/src/modules/mcp/clark-mcp.routes.ts
+++ b/src/modules/mcp/clark-mcp.routes.ts
@@ -1,0 +1,9 @@
+import { HTTPMethod } from "../../shared/types/http-method.type";
+import { ProxyRoute } from "../../shared/types/proxy-route.type";
+
+export const MCP_ROUTES: ProxyRoute[] = [
+    {
+        method: HTTPMethod.POST,
+        path: "/mcp",
+    }
+]

--- a/src/modules/mcp/mcp.router.ts
+++ b/src/modules/mcp/mcp.router.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { ClarkMCPRouteHandler } from "./clark-mcp.router";
+
+export class MCPRouteHandler {
+    public static build(): Router {
+        const router = Router();
+        router.use(ClarkMCPRouteHandler.build());
+
+        return router;
+    }
+}


### PR DESCRIPTION
## What this PR does / why we need it

Adds a new router that will accept a single `POST /mcp` route that will direct traffic towards our `clark_mcp_server` container that is now in staging thanks to changes in [CDK PULL#4](https://github.com/Cyber4All/cyber4all-cdk/pull/4).

Followed the same pattern as Clark and Card by creating 3 new files for the mcp server in `mcp.router.ts`, `clark-mcp.routes.ts`, and `clark-mcp.router.ts`. Then added the router to the general app configuration and updated the environment variables that are needed in the env driver.




## Acceptance Criteria Met

-   [ ] Docs changes if needed
-   [ ] Testing changes if needed
-   [ ] All workflow checks passing (automatically enforced)
-   [ ] All review conversations resolved (automatically enforced)
-   [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
