### PR TITLE
updates to how mcp router is configured

### DIFF
--- a/src/config/express/express.config.ts
+++ b/src/config/express/express.config.ts
@@ -27,7 +27,6 @@ export class ExpressConfig {
      * @returns The Express App
      */
     private static buildDriver() {
-        this.app.use(exp.json());
         this.app.use(cors({ origin: true, credentials: true }));
         this.app.set("trust proxy", true);
         this.app.use(cookieParser());
@@ -40,10 +39,15 @@ export class ExpressConfig {
 
         this.initServerHome();
 
+        // Proxy MCP before JSON body parser
+        this.app.use(MCPRouteHandler.build());
+
+        // JSON parser after proxy routes
+        this.app.use(exp.json());
+
         // Route Handlers Here
         this.app.use(CardRouteHandler.build());
         this.app.use(ClarkRouteHandler.build());
-        this.app.use(MCPRouteHandler.build());
 
         this.app.use(ErrorParser);
 


### PR DESCRIPTION
## What this PR does / why we need it

In staging gateway is experiencing issues proxying the `/mcp` route to the MCP service container, one potential issue could be that the express config file has the line `this.app.use(exp.json());` before `this.app.use(MCPRouteHandler.build());`. For normal REST routes, that is fine. But for proxy routes, especially MCP streamable HTTP, Express may consume the request body before http-proxy-middleware gets it. Then the proxy forwards a request with an empty/invalid body, which can cause ECONNRESET, weird method/body behavior, or failed MCP handshakes. So we're gonna try if switching it around makes a difference. 