### PR TITLE
now using createProxyMiddleware for ClarkMCP

### DIFF
--- a/src/modules/mcp/clark-mcp.router.ts
+++ b/src/modules/mcp/clark-mcp.router.ts
@@ -1,11 +1,26 @@
 import { Router } from "express";
-import { buildProxyRouter } from "../../shared/functions/build-proxy-router";
-import { MCP_ROUTES } from "./clark-mcp.routes";
 import { envConfig } from "../../config/env/env.driver";
 import { MCP_SERVICE_URI } from "../../config/global.env";
+import { createProxyMiddleware } from "http-proxy-middleware/dist";
 
 export class ClarkMCPRouteHandler {
     public static build(): Router {
-        return buildProxyRouter(MCP_ROUTES, envConfig.getUri(MCP_SERVICE_URI));
+        const router = Router();
+
+        router.post(
+            "/mcp",
+            createProxyMiddleware({
+                target: envConfig.getUri(MCP_SERVICE_URI),
+                changeOrigin: true,
+                secure:
+                    envConfig.isProduction() || envConfig.isStaging()
+                        ? true
+                        : false,
+                timeout: 120000,
+                proxyTimeout: 120000,
+            }),
+        );
+
+        return router;
     }
 }


### PR DESCRIPTION
## What this PR does / why we need it

Using a dedicated proxy route for the MCP sever to debug staging setup, instead of using `buildProxyServer()`, and now being able to define timeout.