### PR TITLE
chore: [sc-39811] Update Config.yaml CI Files for Each Service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ workflows:
                             profile_name: ecs_oidc
                             role_arn: $ECS_OIDC_ROLE
                   cluster: prd-cyber4all-cluster-use1-c804ab27
-                  container_image_name_updates: container=prd-clark-gateway-use1-c8577541,tag=latest
+                  container_image_name_updates: container=clark-gateway,tag=latest
                   family: prd-clark-gateway-use1-c8577541
                   profile_name: ecs_oidc
                   verify_revision_is_deployed: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ workflows:
                       - aws-cli/setup:
                             profile_name: ecs_oidc
                             role_arn: $ECS_OIDC_ROLE
-                  cluster: prd-secured-cluster-use1
-                  container_image_name_updates: container=prd-clark-gateway-use1,tag=latest
-                  family: prd-clark-gateway-use1
+                  cluster: prd-cyber4all-cluster-use1-c804ab27
+                  container_image_name_updates: container=prd-clark-gateway-use1-c8577541,tag=latest
+                  family: prd-clark-gateway-use1-c8577541
                   profile_name: ecs_oidc
                   verify_revision_is_deployed: true


### PR DESCRIPTION
# Description
Same deal as the rest of them, replaced the old cluster name with the new cyber4all one, and updated the new service/family name for the container, now the release CI job will update the correct ECS service when we deploy.