### PR TITLE
Feature/sc 39787/add monthly report routes to gateway

### DIFF
--- a/src/modules/clark/report-module/reports.routes.ts
+++ b/src/modules/clark/report-module/reports.routes.ts
@@ -21,6 +21,11 @@ export const REPORTS_ROUTES: ProxyRoute[] = [
     },
     {
         method: HTTPMethod.GET,
+        path: "/reports/top-views",
+        auth: true,
+    },
+    {
+        method: HTTPMethod.GET,
         path: "/reports/top-downloaders",
         auth: true,
     },

--- a/src/modules/clark/report-module/reports.routes.ts
+++ b/src/modules/clark/report-module/reports.routes.ts
@@ -14,4 +14,15 @@ export const REPORTS_ROUTES: ProxyRoute[] = [
         path: "/reports",
         auth: true,
     },
+    {
+        method: HTTPMethod.GET,
+        path: "/reports/top-downloads",
+        auth: true,
+    },
+
+    {
+        method: HTTPMethod.GET,
+        path: "/reports/top-downloaders",
+        auth: true,
+    },
 ];

--- a/src/modules/clark/report-module/reports.routes.ts
+++ b/src/modules/clark/report-module/reports.routes.ts
@@ -25,4 +25,14 @@ export const REPORTS_ROUTES: ProxyRoute[] = [
         path: "/reports/top-downloaders",
         auth: true,
     },
+    {
+        method: HTTPMethod.GET,
+        path: "/reports/top-topics",
+        auth: true,
+    },
+    {
+        method: HTTPMethod.GET,
+        path: "/reports/top-tags",
+        auth: true,
+    },
 ];

--- a/src/modules/clark/report-module/reports.routes.ts
+++ b/src/modules/clark/report-module/reports.routes.ts
@@ -19,7 +19,6 @@ export const REPORTS_ROUTES: ProxyRoute[] = [
         path: "/reports/top-downloads",
         auth: true,
     },
-
     {
         method: HTTPMethod.GET,
         path: "/reports/top-downloaders",


### PR DESCRIPTION
## Summary 
- Added a `GET /reports/top-downloads` gateway route 
- Added a `GET /reports/top-downloaders` gateway route 
- Added a `GET /reports/top-topics` gateway route. 
- Added a `GET /reports/top-tags` gateway route. 
- Added a `GET /reports/top-views` gateway route.