### PR TITLE
Add monthly report routes to Gateway (Contributors)

### DIFF
--- a/src/modules/clark/report-module/reports.routes.ts
+++ b/src/modules/clark/report-module/reports.routes.ts
@@ -31,6 +31,11 @@ export const REPORTS_ROUTES: ProxyRoute[] = [
     },
     {
         method: HTTPMethod.GET,
+        path: "/reports/top-contributors",
+        auth: true,
+    },
+    {
+        method: HTTPMethod.GET,
         path: "/reports/top-topics",
         auth: true,
     },


### PR DESCRIPTION
## Summary 
- Added a `GET /reports/top-contributors` gateway route (it was the only currently missing route from the gateway)
